### PR TITLE
Correct settings for Monoprice 22" and Bosto 22HD

### DIFF
--- a/bosto_2g.c
+++ b/bosto_2g.c
@@ -104,7 +104,7 @@ struct hanwang_features {
 
 static const struct hanwang_features features_array[] = {
 	{ USB_PRODUCT_BOSTO22HD, "Bosto Kingtee 22HD", HANWANG_BOSTO_22HD,
-		PKGLEN_MAX, 0x27de, 0x1cfe, 0x3f, 0x7f, 0x0400 },
+		PKGLEN_MAX, 0xDBE8, 0x79BF, 0x3f, 0x7f, 0x0800 },
 	{ USB_PRODUCT_BOSTO14WA, "Bosto Kingtee 14WA", HANWANG_BOSTO_14WA,
 		PKGLEN_MAX, 0x27de, 0x1cfe, 0x3f, 0x7f, 0x0800 },
 };


### PR DESCRIPTION
Fixed max_x and max_y of 22HD to match Bosto Kingtee 22HD and Monoprice 22